### PR TITLE
Ensure release branch checkout tracks remote reference

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -74,7 +74,8 @@ jobs:
           git fetch origin
           if git ls-remote --exit-code --heads origin $branch; then
             echo "Atualizando branch existente $branch"
-            git checkout $branch
+            git fetch origin $branch
+            git checkout -B $branch origin/$branch
             git merge origin/develop --no-edit || true
           else
             echo "Criando nova release branch $branch"


### PR DESCRIPTION
## Summary
- fetch the existing release branch ref from origin before checking it out
- recreate the local release branch to track the remote ref prior to merging develop

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de870f96a8832a96d034e1d6f5bb34